### PR TITLE
genimage: Set part-type to root-riscv

### DIFF
--- a/genimage.cfg
+++ b/genimage.cfg
@@ -86,5 +86,6 @@ image gentoo-linux-k1_dev-sdcard.img {
             size = ""
             holes = {}
             in-partition-table = "true"
+            partition-type-uuid = "root-{riscv64}"
     }
 }


### PR DESCRIPTION
Setting the partition type correctly allows the host to introspect the proper mount configuration automatically.