### PR TITLE
Add Crossdev overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ emerge bubblewrap
 # Needed to assemble the whole image
 emerge genimage xz-utils
 ```
+# Needed to use crossdev
+```
+emerge app-eselect/eselect-repository
+eselect repository create crossdev
+```
 
 ## Limitations
 


### PR DESCRIPTION
Currently adding crossdev target is failing without an error.

Ref:
https://wiki.gentoo.org/wiki/Crossdev#Crossdev_overlay