### PR TITLE
feat(boards/odroid-m1): add Rockchip RK3566/RK3568 aarch64 board

### DIFF
--- a/boards/odroid-m1/board.conf
+++ b/boards/odroid-m1/board.conf
@@ -1,0 +1,39 @@
+TESTING="true"
+
+BOARD_NAME="odroid-m1"
+BOARD_ARCH="aarch64"
+BOARD_CFLAGS="-O3 -mcpu=cortex-a55+crc+crypto -pipe"
+CROSS_COMPILE="aarch64-unknown-linux-gnu-"
+KERNEL_ARCH="arm64"
+
+# Mainline sources
+KERNEL_REPO="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
+KERNEL_TAG="v7.0"
+KERNEL_DEFCONFIG="defconfig"
+
+U_BOOT_REPO="https://github.com/u-boot/u-boot.git"
+U_BOOT_TAG="v2026.04"
+U_BOOT_DEFCONFIG="odroid-m1-rk3568_defconfig"
+
+# ARM Trusted Firmware (BL31)
+TFA_REPO="https://github.com/ARM-software/arm-trusted-firmware.git"
+TFA_TAG="lts-v2.14.1"
+TFA_PLAT="rk3568"
+
+# Rockchip DDR init blob (closed-source, required)
+RKBIN_REPO="https://github.com/rockchip-linux/rkbin.git"
+RKBIN_DDR="bin/rk35/rk3568_ddr_1560MHz_v*.bin"
+
+BOARD_DTB_GLOB="arch/arm64/boot/dts/rockchip/rk3568-odroid-m1.dtb"
+
+# Boot
+BOOT_ROOT_DEV="/dev/mmcblk0p2"
+BOOT_CONSOLE="ttyS2,1500000"
+BOOT_KERNEL_NAME="Image"
+
+BUILD_STEPS=(deps checkout bootloader kernel assemble pack)
+
+BOOT_SERVICES=("sshd:default" "metalog:default" "ntp-client:default")
+BOOT_HOSTNAME="gentoo"
+BOOT_SERIAL_TTY="ttyS2"
+BOOT_SERIAL_BAUD="1500000"

--- a/boards/odroid-m1/genimage.cfg
+++ b/boards/odroid-m1/genimage.cfg
@@ -1,0 +1,65 @@
+config {
+    outputpath = .
+    inputpath = .
+    rootpath = gen
+    tmppath = tmp
+}
+
+image rootfs.ext4 {
+    ext4 {
+        use-mke2fs = "true"
+        label = "rootfs"
+        extraargs = "-i 4k"
+    }
+
+    size = 5G
+    mountpoint = "/root"
+}
+
+image bootfs.ext4 {
+    ext4 {
+        use-mke2fs = "true"
+        label = "bootfs"
+    }
+
+    size = 256M
+    mountpoint = "/boot"
+}
+
+image gentoo-linux-odroid-m1_dev-sdcard.img {
+    hdimage {
+        partition-table-type = gpt
+    }
+
+    /* idbloader.img at sector 64 (32KB) */
+    partition idbloader {
+        image = "u-boot/idbloader.img"
+        offset = "32K"
+        size = "4M"
+        in-partition-table = "false"
+    }
+
+    /* u-boot.itb at sector 16384 (8MB) */
+    partition uboot {
+        image = "u-boot/u-boot.itb"
+        offset = "8M"
+        size = "4M"
+        in-partition-table = "false"
+    }
+
+    partition bootfs {
+        image = "bootfs.ext4"
+        offset = "16M"
+        size = "256M"
+        partition-type-uuid = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+        in-partition-table = "true"
+    }
+
+    partition rootfs {
+        image = "rootfs.ext4"
+        offset = "272M"
+        size = ""
+        partition-type-uuid = "B921B045-1DF0-41C3-AF44-4C6F280D3FAE"
+        in-partition-table = "true"
+    }
+}

--- a/boards/odroid-m1/override-bootloader.sh
+++ b/boards/odroid-m1/override-bootloader.sh
@@ -1,0 +1,16 @@
+set -e
+
+# 1. Build ARM Trusted Firmware (BL31)
+make -C /build/tfa PLAT=${TFA_PLAT} CROSS_COMPILE=${CROSS_COMPILE} bl31 -j$(nproc)
+
+# 2. Resolve DDR blob (glob pattern, exclude eyescan, pick latest)
+DDR_BLOB=$(ls /build/rkbin/${RKBIN_DDR} 2>/dev/null | grep -v eyescan | sort -V | tail -1)
+[ -z "$DDR_BLOB" ] && { echo "Error: no DDR blob matching ${RKBIN_DDR}" >&2; exit 1; }
+echo "Using DDR blob: $DDR_BLOB"
+
+# 3. Build U-Boot with TF-A and DDR blob
+export ROCKCHIP_TPL="$DDR_BLOB"
+export BL31=/build/tfa/build/${TFA_PLAT}/release/bl31/bl31.elf
+
+make -C /build/u-boot CROSS_COMPILE=${CROSS_COMPILE} ${U_BOOT_DEFCONFIG}
+make -C /build/u-boot CROSS_COMPILE=${CROSS_COMPILE} -j$(nproc)

--- a/boards/odroid-m1/override-checkout.sh
+++ b/boards/odroid-m1/override-checkout.sh
@@ -1,0 +1,17 @@
+set -e
+
+clone_cached() {
+    local repo=$1 tag=$2 dest=$3 name=$4
+    local cache="/cache/sources/${name}.git"
+    if [ -d "$cache" ]; then
+        git -C "$cache" fetch --prune 2>/dev/null || true
+    else
+        git clone --bare "$repo" "$cache"
+    fi
+    git clone --reference "$cache" --depth=1 --branch "$tag" "$repo" "$dest"
+}
+
+clone_cached "${RKBIN_REPO}" master /build/rkbin rkbin
+clone_cached "${TFA_REPO}" "${TFA_TAG}" /build/tfa arm-trusted-firmware
+clone_cached "${U_BOOT_REPO}" "${U_BOOT_TAG}" /build/u-boot u-boot-upstream
+clone_cached "${KERNEL_REPO}" "${KERNEL_TAG}" /build/linux linux-mainline

--- a/boards/odroid-m1/post-assemble.sh
+++ b/boards/odroid-m1/post-assemble.sh
@@ -1,0 +1,28 @@
+set -e
+
+# Ensure virtual-fs mountpoints exist in the rootfs.
+# cross-emerged baselayout doesn't reliably create these, and without /dev
+# the kernel can't auto-mount devtmpfs, leaving init with no /dev/console
+# (boot silently hangs after "Run /sbin/init as init process").
+mkdir -p /build/gen/root/dev \
+         /build/gen/root/proc \
+         /build/gen/root/sys \
+         /build/gen/root/run \
+         /build/gen/root/tmp \
+         /build/gen/root/mnt \
+         /build/gen/root/media
+chmod 1777 /build/gen/root/tmp
+
+# Extlinux boot config
+mkdir -p /build/gen/boot/extlinux
+kver=$(ls /build/gen/root/lib/modules/ | head -1)
+[ -z "$kver" ] && { echo 'Error: no kernel modules found'; exit 1; }
+cat > /build/gen/boot/extlinux/extlinux.conf << EXTEOF
+DEFAULT gentoo
+TIMEOUT 30
+LABEL gentoo
+    MENU LABEL Gentoo Linux
+    LINUX /${BOOT_KERNEL_NAME}
+    FDT /rk3568-odroid-m1.dtb
+    APPEND root=${BOOT_ROOT_DEV} rw rootwait rootfstype=ext4 console=${BOOT_CONSOLE} earlycon
+EXTEOF

--- a/boards/odroid-m1/target-packages.txt
+++ b/boards/odroid-m1/target-packages.txt
@@ -1,0 +1,2 @@
+net-misc/openssh
+sys-apps/busybox

--- a/boards/odroid-m1s/board.conf
+++ b/boards/odroid-m1s/board.conf
@@ -1,0 +1,40 @@
+TESTING="true"
+
+BOARD_NAME="odroid-m1s"
+BOARD_ARCH="aarch64"
+BOARD_CFLAGS="-O3 -mcpu=cortex-a55+crc+crypto -pipe"
+CROSS_COMPILE="aarch64-unknown-linux-gnu-"
+KERNEL_ARCH="arm64"
+
+# Mainline sources
+KERNEL_REPO="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
+KERNEL_TAG="v7.0"
+KERNEL_DEFCONFIG="defconfig"
+
+U_BOOT_REPO="https://github.com/u-boot/u-boot.git"
+U_BOOT_TAG="v2026.04"
+U_BOOT_DEFCONFIG="odroid-m1s-rk3566_defconfig"
+
+# ARM Trusted Firmware (BL31) — RK3566 shares the rk3568 TFA platform
+TFA_REPO="https://github.com/ARM-software/arm-trusted-firmware.git"
+TFA_TAG="lts-v2.14.1"
+TFA_PLAT="rk3568"
+
+# Rockchip DDR init blob (closed-source, required)
+# RK3566 has its own DDR blob, distinct from RK3568
+RKBIN_REPO="https://github.com/rockchip-linux/rkbin.git"
+RKBIN_DDR="bin/rk35/rk3566_ddr_1056MHz_v*.bin"
+
+BOARD_DTB_GLOB="arch/arm64/boot/dts/rockchip/rk3566-odroid-m1s.dtb"
+
+# Boot
+BOOT_ROOT_DEV="/dev/mmcblk0p2"
+BOOT_CONSOLE="ttyS2,1500000"
+BOOT_KERNEL_NAME="Image"
+
+BUILD_STEPS=(deps checkout bootloader kernel assemble pack)
+
+BOOT_SERVICES=("sshd:default" "metalog:default" "ntp-client:default")
+BOOT_HOSTNAME="gentoo"
+BOOT_SERIAL_TTY="ttyS2"
+BOOT_SERIAL_BAUD="1500000"

--- a/boards/odroid-m1s/genimage.cfg
+++ b/boards/odroid-m1s/genimage.cfg
@@ -1,0 +1,65 @@
+config {
+    outputpath = .
+    inputpath = .
+    rootpath = gen
+    tmppath = tmp
+}
+
+image rootfs.ext4 {
+    ext4 {
+        use-mke2fs = "true"
+        label = "rootfs"
+        extraargs = "-i 4k"
+    }
+
+    size = 5G
+    mountpoint = "/root"
+}
+
+image bootfs.ext4 {
+    ext4 {
+        use-mke2fs = "true"
+        label = "bootfs"
+    }
+
+    size = 256M
+    mountpoint = "/boot"
+}
+
+image gentoo-linux-odroid-m1s_dev-sdcard.img {
+    hdimage {
+        partition-table-type = gpt
+    }
+
+    /* idbloader.img at sector 64 (32KB) */
+    partition idbloader {
+        image = "u-boot/idbloader.img"
+        offset = "32K"
+        size = "4M"
+        in-partition-table = "false"
+    }
+
+    /* u-boot.itb at sector 16384 (8MB) */
+    partition uboot {
+        image = "u-boot/u-boot.itb"
+        offset = "8M"
+        size = "4M"
+        in-partition-table = "false"
+    }
+
+    partition bootfs {
+        image = "bootfs.ext4"
+        offset = "16M"
+        size = "256M"
+        partition-type-uuid = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+        in-partition-table = "true"
+    }
+
+    partition rootfs {
+        image = "rootfs.ext4"
+        offset = "272M"
+        size = ""
+        partition-type-uuid = "B921B045-1DF0-41C3-AF44-4C6F280D3FAE"
+        in-partition-table = "true"
+    }
+}

--- a/boards/odroid-m1s/override-bootloader.sh
+++ b/boards/odroid-m1s/override-bootloader.sh
@@ -1,0 +1,17 @@
+set -e
+
+# 1. Build ARM Trusted Firmware (BL31)
+# RK3566 shares the rk3568 TFA platform
+make -C /build/tfa PLAT=${TFA_PLAT} CROSS_COMPILE=${CROSS_COMPILE} bl31 -j$(nproc)
+
+# 2. Resolve DDR blob (glob pattern, exclude eyescan, pick latest)
+DDR_BLOB=$(ls /build/rkbin/${RKBIN_DDR} 2>/dev/null | grep -v eyescan | sort -V | tail -1)
+[ -z "$DDR_BLOB" ] && { echo "Error: no DDR blob matching ${RKBIN_DDR}" >&2; exit 1; }
+echo "Using DDR blob: $DDR_BLOB"
+
+# 3. Build U-Boot with TF-A and DDR blob
+export ROCKCHIP_TPL="$DDR_BLOB"
+export BL31=/build/tfa/build/${TFA_PLAT}/release/bl31/bl31.elf
+
+make -C /build/u-boot CROSS_COMPILE=${CROSS_COMPILE} ${U_BOOT_DEFCONFIG}
+make -C /build/u-boot CROSS_COMPILE=${CROSS_COMPILE} -j$(nproc)

--- a/boards/odroid-m1s/override-checkout.sh
+++ b/boards/odroid-m1s/override-checkout.sh
@@ -1,0 +1,17 @@
+set -e
+
+clone_cached() {
+    local repo=$1 tag=$2 dest=$3 name=$4
+    local cache="/cache/sources/${name}.git"
+    if [ -d "$cache" ]; then
+        git -C "$cache" fetch --prune 2>/dev/null || true
+    else
+        git clone --bare "$repo" "$cache"
+    fi
+    git clone --reference "$cache" --depth=1 --branch "$tag" "$repo" "$dest"
+}
+
+clone_cached "${RKBIN_REPO}" master /build/rkbin rkbin
+clone_cached "${TFA_REPO}" "${TFA_TAG}" /build/tfa arm-trusted-firmware
+clone_cached "${U_BOOT_REPO}" "${U_BOOT_TAG}" /build/u-boot u-boot-upstream
+clone_cached "${KERNEL_REPO}" "${KERNEL_TAG}" /build/linux linux-mainline

--- a/boards/odroid-m1s/post-assemble.sh
+++ b/boards/odroid-m1s/post-assemble.sh
@@ -1,0 +1,28 @@
+set -e
+
+# Ensure virtual-fs mountpoints exist in the rootfs.
+# cross-emerged baselayout doesn't reliably create these, and without /dev
+# the kernel can't auto-mount devtmpfs, leaving init with no /dev/console
+# (boot silently hangs after "Run /sbin/init as init process").
+mkdir -p /build/gen/root/dev \
+         /build/gen/root/proc \
+         /build/gen/root/sys \
+         /build/gen/root/run \
+         /build/gen/root/tmp \
+         /build/gen/root/mnt \
+         /build/gen/root/media
+chmod 1777 /build/gen/root/tmp
+
+# Extlinux boot config
+mkdir -p /build/gen/boot/extlinux
+kver=$(ls /build/gen/root/lib/modules/ | head -1)
+[ -z "$kver" ] && { echo 'Error: no kernel modules found'; exit 1; }
+cat > /build/gen/boot/extlinux/extlinux.conf << EXTEOF
+DEFAULT gentoo
+TIMEOUT 30
+LABEL gentoo
+    MENU LABEL Gentoo Linux
+    LINUX /${BOOT_KERNEL_NAME}
+    FDT /rk3566-odroid-m1s.dtb
+    APPEND root=${BOOT_ROOT_DEV} rw rootwait rootfstype=ext4 console=${BOOT_CONSOLE} earlycon
+EXTEOF

--- a/boards/odroid-m1s/target-packages.txt
+++ b/boards/odroid-m1s/target-packages.txt
@@ -1,0 +1,2 @@
+net-misc/openssh
+sys-apps/busybox


### PR DESCRIPTION
Support RK3566(odroid-m1s), RK3568(odroid-m1) board.

- Add configs, DTBs, rkbin, and CFLAGS for RK3566/RK3568 based on borads/odroid-m2

HOTFIX:

Kernel boot hang caused by missing /dev mounting, which prevented init from accessing /dev/console. Add required rootfs directories such as /dev, /proc, /sys ... in post-assemble.sh for now; I think this should be handled properly in the Rust layer.