### PR TITLE
feat(image): first-boot grow-rootfs oneshot service

### DIFF
--- a/crossdev-stages/src/image.rs
+++ b/crossdev-stages/src/image.rs
@@ -231,6 +231,17 @@ fn default_assemble(runner: &SandboxRunner, board: &BoardConfig) -> Result<()> {
 
     runner
         .run("mkdir -p /build/gen/root/etc/runlevels/{boot,default,nonetwork,shutdown,sysinit}")?;
+
+    // Board-agnostic: grow-rootfs oneshot, runs once on first boot, fills
+    // the rootfs partition out to the disk end + resize2fs.  Needs
+    // sys-block/parted + sys-fs/e2fsprogs in the target.
+    runner.run(
+        "install -m 0755 /scripts/defaults/scripts/grow-rootfs.initd \
+           /build/gen/root/etc/init.d/grow-rootfs && \
+         ln -sf /etc/init.d/grow-rootfs \
+           /build/gen/root/etc/runlevels/boot/grow-rootfs",
+    )?;
+
     for svc in &board.services {
         if let Some((name, runlevel)) = svc.split_once(':') {
             runner.run(&format!(

--- a/defaults/scripts/grow-rootfs.initd
+++ b/defaults/scripts/grow-rootfs.initd
@@ -1,0 +1,59 @@
+#!/sbin/openrc-run
+# Resize the rootfs partition to fill its underlying disk on first boot,
+# then resize the ext4 filesystem to match.  After the first successful
+# run, leaves a marker file and short-circuits on subsequent boots.
+#
+# Why: images ship with a fixed-size rootfs (e.g. 5 GB) to keep the .img
+# small.  On real storage (UFS / eMMC / SD card / NVMe) the underlying
+# partition is much larger, but the filesystem still thinks it's 5 GB
+# until something grows it.
+
+description="Grow rootfs filesystem to fill its partition on first boot"
+
+depend() {
+    need root
+    before *
+}
+
+start() {
+    [ -f /etc/.rootfs-grown ] && return 0
+
+    local src disk part
+    src=$(findmnt -n -o SOURCE /)
+    case "$src" in
+        /dev/mmcblk*p*|/dev/nvme*n*p*)
+            disk=${src%p*}
+            part=${src##*p}
+            ;;
+        /dev/sd[a-z]*|/dev/vd[a-z]*|/dev/xvd[a-z]*)
+            disk=$(echo "$src" | sed -E 's/[0-9]+$//')
+            part=$(echo "$src" | grep -oE '[0-9]+$')
+            ;;
+        *)
+            ewarn "Unsupported root device pattern: $src"
+            return 0
+            ;;
+    esac
+
+    if [ -z "$disk" ] || [ -z "$part" ]; then
+        ewarn "Could not parse disk/partition from $src"
+        return 0
+    fi
+
+    ebegin "Growing partition $part on $disk to disk end"
+    parted -s "$disk" resizepart "$part" 100% || {
+        eend $? "parted resizepart failed"
+        return 0
+    }
+    eend 0
+
+    ebegin "Resizing ext4 on $src"
+    resize2fs "$src" || {
+        eend $? "resize2fs failed"
+        return 0
+    }
+    eend 0
+
+    touch /etc/.rootfs-grown
+    einfo "Rootfs grown.  Marker /etc/.rootfs-grown created."
+}


### PR DESCRIPTION
Images ship with a fixed-size rootfs (e.g. 5G) to keep the .img small. On real storage the underlying partition is much larger, but the filesystem stays at the shipped size until something resizes it.

Add an OpenRC oneshot at /etc/init.d/grow-rootfs that on first boot:

  1. parses the mounted rootfs source (/dev/sda3, /dev/mmcblk0p7, /dev/nvme0n1p3 patterns supported);
  2. `parted -s <disk> resizepart <N> 100%` — pushes the partition to the disk end;
  3. `resize2fs <src>` — grows the ext4 to fill;
  4. touches /etc/.rootfs-grown so it short-circuits next boot.

Symlinked into the boot runlevel from image.rs::default_assemble so all boards get it by default.  Boards need `sys-block/parted` in their target packages — to be added per board.